### PR TITLE
🔥 remove unused pr checkbox

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,6 +3,5 @@
 - [ ] closes #xxxx
 - [ ] README entry added if new functionality
 - [ ] fixup commits are appropriately squashed
-- [ ] submission_packet has been regenerated and committed as last commit in this PR
 
 [Description here]


### PR DESCRIPTION
# 🔥 remove unused pr checkbox

- [ ] closes #xxxx
- [ ] README entry added if new functionality
- [ ] fixup commits are appropriately squashed
- [ ] submission_packet has been regenerated and committed as last commit in this PR

the checkbox was for a different project. it shouldn't be here